### PR TITLE
Fixed #213 and add prefer local ip address option.

### DIFF
--- a/src/Apollo.Configuration/ApolloConfigurationExtensions.cs
+++ b/src/Apollo.Configuration/ApolloConfigurationExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Configuration
         public static IApolloConfigurationBuilder AddApollo(this IConfigurationBuilder builder, IApolloOptions options)
         {
             if (builder.Properties.ContainsKey(typeof(ApolloConfigurationExtensions).FullName))
-                throw new InvalidOperationException("Do not repeat init apollo");
+                throw new InvalidOperationException("Do not repeat init apollo.");
 
             var repositoryFactory = new ConfigRepositoryFactory(options ?? throw new ArgumentNullException(nameof(options)));
 
@@ -28,13 +28,15 @@ namespace Microsoft.Extensions.Configuration
             if (options is ApolloOptions { Namespaces: { } } ao)
                 foreach (var ns in ao.Namespaces) acb.AddNamespace(ns);
 
+            builder.Properties[typeof(ApolloConfigurationExtensions).FullName] = acb;
+
             return acb;
         }
 
         public static IApolloConfigurationBuilder AddApollo(this IConfigurationBuilder builder)
         {
             if (!builder.Properties.TryGetValue(typeof(ApolloConfigurationExtensions).FullName, out var apolloBuilder))
-                throw new InvalidOperationException("Please invoke 'AddApollo(options)' init apollo at the beginning.");
+                throw new InvalidOperationException("Please call 'AddApollo(options)' to init apollo at the beginning.");
 
             return (ApolloConfigurationBuilder)apolloBuilder;
 

--- a/src/Apollo.Configuration/ApolloConfigurationExtensions.cs
+++ b/src/Apollo.Configuration/ApolloConfigurationExtensions.cs
@@ -48,19 +48,39 @@ namespace Com.Ctrip.Framework.Apollo
 {
     public static class ApolloConfigurationBuilderExtensions
     {
-        /// <summary>添加默认namespace: application，等价于AddNamespace(ConfigConsts.NamespaceApplication)</summary>
+        /// <summary>
+        /// Add default namespace(application)，equivalent to AddNamespace(ConfigConsts.NamespaceApplication)
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="format">The content format of the default namespace</param>
+        /// <returns></returns>
         public static IApolloConfigurationBuilder AddDefault(this IApolloConfigurationBuilder builder, ConfigFileFormat format = ConfigFileFormat.Properties) =>
             builder.AddNamespace(ConfigConsts.NamespaceApplication, null, format);
 
-        /// <summary>添加其他namespace</summary>
+        /// <summary>
+        /// Add namespace
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="namespace">The namespace name</param>
+        /// <param name="format">The content format of the <paramref name="namespace"/></param>
+        /// <returns></returns>
         public static IApolloConfigurationBuilder AddNamespace(this IApolloConfigurationBuilder builder, string @namespace, ConfigFileFormat format = ConfigFileFormat.Properties) =>
             builder.AddNamespace(@namespace, null, format);
 
-        /// <summary>添加其他namespace。如果sectionKey为null则添加到root中，可以直接读取，否则使用Configuration.GetSection(sectionKey)读取</summary>
+        /// <summary>
+        /// Add namespace
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="namespace">The namespace name</param>
+        /// <param name="sectionKey">As prefix adds to <see cref="IConfiguration"/>, Using <paramref name="sectionKey"/> as an argument to <see cref="IConfiguration.GetSection(string)"/> to get the content of <paramref name="namespace"/>.</param>
+        /// <param name="format">The content format of the <paramref name="namespace"/></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static IApolloConfigurationBuilder AddNamespace(this IApolloConfigurationBuilder builder, string @namespace, string? sectionKey, ConfigFileFormat format = ConfigFileFormat.Properties)
         {
             if (string.IsNullOrWhiteSpace(@namespace)) throw new ArgumentNullException(nameof(@namespace));
-            if (format is < ConfigFileFormat.Properties or > ConfigFileFormat.Txt) throw new ArgumentOutOfRangeException(nameof(format), format, $"最小值{ConfigFileFormat.Properties}，最大值{ConfigFileFormat.Txt}");
+            if (format is < ConfigFileFormat.Properties or > ConfigFileFormat.Txt) throw new ArgumentOutOfRangeException(nameof(format), format, $"minimum:{ConfigFileFormat.Properties}，maximum:{ConfigFileFormat.Txt}");
 
             if (format != ConfigFileFormat.Properties) @namespace += "." + format.GetString();
 

--- a/src/Apollo.Configuration/ApolloConfigurationManager.cs
+++ b/src/Apollo.Configuration/ApolloConfigurationManager.cs
@@ -7,7 +7,7 @@ namespace Com.Ctrip.Framework.Apollo;
 /// <summary>
 /// Entry point for client config use
 /// </summary>
-[Obsolete("不建议使用，后续版本可能删除，推荐使用Microsoft.Extensions.Configuration.IConfiguration", true)]
+[Obsolete("It is not recommended to use the following version, which may delete the recommended Microsoft.Extensions.Configuration.IConfiguration", true)]
 public class ApolloConfigurationManager
 {
     public static IConfigManager Manager => ApolloConfigurationManagerHelper.Manager;

--- a/src/Apollo.Configuration/ApolloOptions.cs
+++ b/src/Apollo.Configuration/ApolloOptions.cs
@@ -53,7 +53,29 @@ public class ApolloOptions : IApolloOptions
     /// <summary>Default Dev</summary>
     public virtual Env Env { get; set; } = Env.Dev;
 
-    public virtual string LocalIp { get; set; } = NetworkInterfaceManager.HostIp;
+    private string? _localIp;
+    private string? _preferLocalIpAddress;
+
+    public virtual string? PreferLocalIpAddress
+    {
+        get => this._preferLocalIpAddress;
+        set
+        {
+            this._preferLocalIpAddress = value; this._localIp = null;
+        }
+    }
+    public virtual string LocalIp
+    {
+        get
+        {
+            if (this._localIp == null)
+            {
+                this._localIp = NetworkInterfaceManager.GetHostIp(this.PreferLocalIpAddress);
+            }
+            return this._localIp;
+        }
+        set { this._localIp = value; }
+    }
 
     /// <summary>Default http://localhost:8080</summary>
     public virtual string? MetaServer
@@ -97,7 +119,7 @@ public class ApolloOptions : IApolloOptions
         }
     }
 
-    [Obsolete("请使用HttpMessageHandler", true)]
+    [Obsolete("Please using the HttpMessageHandler property to configure.", true)]
     public Func<HttpMessageHandler> HttpMessageHandlerFactory
     {
         get => () => _handler;

--- a/src/Apollo/Foundation/NetworkInterfaceManager.cs
+++ b/src/Apollo/Foundation/NetworkInterfaceManager.cs
@@ -1,30 +1,98 @@
-﻿using System.Net.NetworkInformation;
+﻿using Com.Ctrip.Framework.Apollo.Logging;
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace Com.Ctrip.Framework.Apollo.Foundation;
 
 public class NetworkInterfaceManager
 {
+    private static readonly string[] hostIps = default!;
     static NetworkInterfaceManager()
     {
         try
         {
-            var hostIp = NetworkInterface.GetAllNetworkInterfaces()
-                .Where(network => network.OperationalStatus == OperationalStatus.Up)
-                .Select(network => network.GetIPProperties())
-                .OrderByDescending(properties => properties.GatewayAddresses.Count)
-                .SelectMany(properties => properties.UnicastAddresses)
-                .FirstOrDefault(address => !IPAddress.IsLoopback(address.Address) &&
-                                           address.Address.AddressFamily == AddressFamily.InterNetwork);
+            hostIps = NetworkInterface.GetAllNetworkInterfaces()
+               .Where(network => network.OperationalStatus == OperationalStatus.Up)
+               .Select(network => network.GetIPProperties())
+               .OrderByDescending(properties => properties.GatewayAddresses.Count)
+               .SelectMany(properties => properties.UnicastAddresses)
+               .Where(address => !IPAddress.IsLoopback(address.Address) && address.Address.AddressFamily == AddressFamily.InterNetwork)
+               .Select(address => address.Address.ToString())
+               .ToArray();
 
-            if (hostIp != null)
-                HostIp = hostIp.Address.ToString();
+            if (hostIps.Any())
+            {
+                HostIp = hostIps.First();
+            }
         }
         catch
         {
             // ignored
+#if NETSTANDARD
+            hostIps = Array.Empty<string>();
+#else
+            hostIps = new string[0];
+#endif
         }
     }
 
     public static string HostIp { get; } = "127.0.0.1";
+
+    public static string GetHostIp(string? preferLocalIpAddress)
+    {
+        if (string.IsNullOrEmpty(preferLocalIpAddress))
+        {
+            return HostIp;
+        }
+
+        try
+        {
+            if (IsInSubnet(hostIps, preferLocalIpAddress!.Split(','), out var ip))
+            {
+                return ip!;
+            }
+        }
+        catch (Exception ex)
+        {
+            LogManager.CreateLogger(typeof(NetworkInterfaceManager)).Error($"Can not get local ip address with prefer option '{preferLocalIpAddress}'.", ex);
+        }
+        return HostIp;
+    }
+    internal static bool IsInSubnet(string[] ips, string[] cidrs, out string? matchedIp)
+    {
+        foreach (var cidr in cidrs)
+        {
+            if (string.IsNullOrEmpty(cidr)) continue;
+
+            foreach (var ip in ips)
+            {
+                if (string.IsNullOrEmpty(ip)) continue;
+
+                if (IsInSubnet(ip, cidr))
+                {
+                    matchedIp = ip;
+                    return true;
+                }
+            }
+        }
+        matchedIp = default;
+        return false;
+    }
+    internal static bool IsInSubnet(string ipAddress, string cidr)
+    {
+        string[] parts = cidr.Split('/');
+
+        int baseAddress = BitConverter.ToInt32(IPAddress.Parse(parts[0]).GetAddressBytes(), 0);
+
+        int address = BitConverter.ToInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0);
+
+        int mask = IPAddress.HostToNetworkOrder(-1 << (32 - int.Parse(parts[1])));
+
+        return ((baseAddress & mask) == (address & mask));
+
+    }
 }

--- a/src/Apollo/IConfigAdapter.cs
+++ b/src/Apollo/IConfigAdapter.cs
@@ -23,7 +23,7 @@ public abstract class ContentConfigAdapter : IConfigAdapter
 
         if (!string.IsNullOrWhiteSpace(content)) return GetProperties(content!);
 
-        Logger().Warn("找不到" + ConfigConsts.ConfigFileContentKey);
+        Logger().Warn("Can not find " + ConfigConsts.ConfigFileContentKey);
 
         return properties;
     }

--- a/src/Apollo/Internals/ConfigRepositoryFactory.cs
+++ b/src/Apollo/Internals/ConfigRepositoryFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Com.Ctrip.Framework.Apollo.Enums;
+using Com.Ctrip.Framework.Apollo.Logging;
 using Com.Ctrip.Framework.Apollo.Util.Http;
 
 namespace Com.Ctrip.Framework.Apollo.Internals;
@@ -26,7 +27,7 @@ public class ConfigRepositoryFactory : IConfigRepositoryFactory, IDisposable
     {
         if (Env.Local.Equals(_options.Env))
         {
-            Console.WriteLine("==== Apollo is in local mode! Won\'t pull configs from remote server! ====");
+            LogManager.CreateLogger(typeof(ConfigRepositoryFactory)).Warn($"==== Apollo is in local mode! Won't pull configs '{@namespace}' from remote server! ====");
             return new LocalFileConfigRepository(@namespace, _options);
         }
 

--- a/test/Apollo.Tests/NetworkInterfaceManagerTests.cs
+++ b/test/Apollo.Tests/NetworkInterfaceManagerTests.cs
@@ -1,0 +1,33 @@
+﻿using Com.Ctrip.Framework.Apollo.Foundation;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Apollo.Tests;
+public class NetworkInterfaceManagerTests
+{
+    [Theory]
+    [InlineData("127.0.0.1", "127.0.0.1/8", "127.0.0.1")]
+    [InlineData("127.255.255.1", "127.0.0.1/8", "127.255.255.1")]
+    [InlineData("172.2.2.1", "172.2.2.1/32", "172.2.2.1")]
+    [InlineData("192.168.1.1", "192.168.1.1/32", "192.168.1.1")]
+    [InlineData("127.0.0.1", "172.0.0.1/8", null)]
+    [InlineData("127.0.0.1", "172.0.0.1/8,127.0.0.1/8", "127.0.0.1")]
+
+    [InlineData("127.0.0.1,172.0.0.1", "172.0.0.1/8,127.0.0.1/8", "172.0.0.1")]
+    [InlineData("172.0.0.1,127.0.0.1", "172.0.0.1/8,127.0.0.1/8", "172.0.0.1")]
+
+    [InlineData("127.0.0.1,172.0.0.1", "127.0.0.1/8,172.0.0.1/8", "127.0.0.1")]
+    [InlineData("172.0.0.1,127.0.0.1", "127.0.0.1/8,172.0.0.1/8", "127.0.0.1")]
+    public void IsInSubnet_Expected(string address, string cidr, string matchedIp)
+    {
+        NetworkInterfaceManager.IsInSubnet(address.Split(','), cidr.Split(','), out var ip);
+
+        Assert.Equal(matchedIp, ip);
+    }
+}


### PR DESCRIPTION
如果运行的机器存在多个出口ip的时候, 可能导致上报到Apollo/实例列表中的ip出现不一致的情况. 通过添加`PreferLocalAdress` 来控制上报要使用的ip. 
`PreferLocalAdress` 支持使用多个cidr表达式来选择ip. 格式: `172.0.0.1/8,192.0.0.1/8`

例如部署的container 有2个ip: 172.16.2.1, 169.254.1.1, 如果要上报172的ip 可以配置`PreferLocalAdress` = "172.0.0.1/8" 