### PR TITLE
Add a switch to support to disable local file cache

### DIFF
--- a/src/Apollo.Configuration/ApolloOptions.cs
+++ b/src/Apollo.Configuration/ApolloOptions.cs
@@ -96,6 +96,8 @@ public class ApolloOptions : IApolloOptions
     /// <summary>ms. Default 300,000ms</summary>
     public virtual int RefreshInterval { get; set; } = 5 * 60 * 1000; //5 minutes
 
+    public bool EnableLocalFileCache { get; set; } = true;
+
     public string? LocalCacheDir { get; set; }
 
     public IDictionary<string, string> Meta { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Apollo.ConfigurationManager/Util/ConfigUtil.cs
+++ b/src/Apollo.ConfigurationManager/Util/ConfigUtil.cs
@@ -2,6 +2,7 @@
 using Com.Ctrip.Framework.Apollo.Enums;
 using Com.Ctrip.Framework.Apollo.Foundation;
 using Com.Ctrip.Framework.Apollo.Logging;
+
 using System.Collections.ObjectModel;
 using System.Configuration;
 
@@ -186,6 +187,8 @@ public class ConfigUtil : IApolloOptions
     }
 
     public int RefreshInterval => _refreshInterval;
+
+    public bool EnableLocalFileCache => bool.TryParse(GetAppConfig(nameof(EnableLocalFileCache)), out var enableLocalFileCache) && enableLocalFileCache;
 
     public string LocalCacheDir => GetAppConfig(nameof(LocalCacheDir)) ?? Path.Combine(ConfigConsts.DefaultLocalCacheDir, AppId);
 

--- a/src/Apollo/IApolloOptions.cs
+++ b/src/Apollo/IApolloOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Com.Ctrip.Framework.Apollo.Enums;
+
 using System.Collections.ObjectModel;
 
 namespace Com.Ctrip.Framework.Apollo;
@@ -44,6 +45,7 @@ public interface IApolloOptions : IDisposable
     /// <summary>Refresh interval. ms</summary>
     int RefreshInterval { get; }
 
+    bool EnableLocalFileCache { get; }
     string? LocalCacheDir { get; }
 
     HttpMessageHandler HttpMessageHandler { get; }
@@ -57,4 +59,5 @@ public interface IApolloOptions : IDisposable
 #else
     IReadOnlyCollection<string>? SpecialDelimiter { get; }
 #endif
+
 }

--- a/src/Apollo/Internals/ConfigRepositoryFactory.cs
+++ b/src/Apollo/Internals/ConfigRepositoryFactory.cs
@@ -30,8 +30,12 @@ public class ConfigRepositoryFactory : IConfigRepositoryFactory, IDisposable
             LogManager.CreateLogger(typeof(ConfigRepositoryFactory)).Warn($"==== Apollo is in local mode! Won't pull configs '{@namespace}' from remote server! ====");
             return new LocalFileConfigRepository(@namespace, _options);
         }
-
-        return new LocalFileConfigRepository(@namespace, _options, new RemoteConfigRepository(@namespace, _options, _httpUtil, _serviceLocator, _remoteConfigLongPollService));
+        var remoteRepo = new RemoteConfigRepository(@namespace, _options, _httpUtil, _serviceLocator, _remoteConfigLongPollService);
+        if (!_options.EnableLocalFileCache)
+        {
+            return remoteRepo;
+        }
+        return new LocalFileConfigRepository(@namespace, _options, remoteRepo);
     }
 
     public void Dispose()


### PR DESCRIPTION
在容器环境中对本地的配置缓存文件不存在必要性. 
1. 容器不存在重启等重用配置的case.
2. 容器中默认情况下对 /opt 目录是没有写入权限的.